### PR TITLE
Assorted fixups to get building on FreeBSD

### DIFF
--- a/analyzer/insp-server.c
+++ b/analyzer/insp-server.c
@@ -107,7 +107,7 @@ suscan_inspector_spectrum_loop(
     while (samp_count > 0) {
       fed = suscan_spectsrc_feed(src, samp_buf, samp_count);
       if (fed < samp_count) {
-        clock_gettime(CLOCK_MONOTONIC_RAW, &now);
+        clock_gettime(CLOCK_MONOTONIC, &now);
         timespecsub(&now, &insp->last_spectrum, &sub);
         seconds = sub.tv_sec + 1e-9 * sub.tv_nsec;
         if (seconds >= insp->interval_spectrum) {
@@ -181,7 +181,7 @@ suscan_inspector_estimator_loop(
 
   /* Check esimator state and update clients */
   if (insp->interval_estimator > 0) {
-    clock_gettime(CLOCK_MONOTONIC_RAW, &now);
+    clock_gettime(CLOCK_MONOTONIC, &now);
     timespecsub(&now, &insp->last_estimator, &sub);
     seconds = sub.tv_sec + 1e-9 * sub.tv_nsec;
     if (seconds >= insp->interval_estimator) {

--- a/analyzer/inspector/inspector.c
+++ b/analyzer/inspector/inspector.c
@@ -218,8 +218,8 @@ suscan_inspector_new(
   new->interval_spectrum  = .1;
 
   /* Initialize clocks */
-  clock_gettime(CLOCK_MONOTONIC_RAW, &new->last_estimator);
-  clock_gettime(CLOCK_MONOTONIC_RAW, &new->last_spectrum);
+  clock_gettime(CLOCK_MONOTONIC, &new->last_estimator);
+  clock_gettime(CLOCK_MONOTONIC, &new->last_spectrum);
 
   /* All set to call specific inspector */
   new->iface = iface;

--- a/analyzer/throttle.c
+++ b/analyzer/throttle.c
@@ -36,7 +36,7 @@ suscan_throttle_init(suscan_throttle_t *throttle, SUSCOUNT samp_rate)
   memset(throttle, 0, sizeof(suscan_throttle_t));
   throttle->samp_rate = samp_rate;
 
-  clock_gettime(CLOCK_MONOTONIC_RAW, &throttle->t0);
+  clock_gettime(CLOCK_MONOTONIC, &throttle->t0);
 
   /*
    * In some circumstances, if both calls to clock_gettime happen
@@ -61,7 +61,7 @@ suscan_throttle_get_portion(suscan_throttle_t *throttle, SUSCOUNT h)
   if (h > 0) {
     do {
       retry = SU_FALSE;
-      clock_gettime(CLOCK_MONOTONIC_RAW, &tn);
+      clock_gettime(CLOCK_MONOTONIC, &tn);
 
       timespecsub(&tn, &throttle->t0, &sub);
 

--- a/analyzer/throttle.h
+++ b/analyzer/throttle.h
@@ -39,6 +39,7 @@ struct suscan_throttle {
 
 typedef struct suscan_throttle suscan_throttle_t;
 
+#ifndef timespecsub
 SUINLINE void
 timespecsub(
     struct timespec *a,
@@ -53,6 +54,7 @@ timespecsub(
     --sub->tv_sec;
   }
 }
+#endif
 
 void suscan_throttle_init(suscan_throttle_t *throttle, SUSCOUNT samp_rate);
 

--- a/util/cfg.c
+++ b/util/cfg.c
@@ -20,6 +20,7 @@
 
 #include <string.h>
 #include <stdlib.h>
+#include <inttypes.h>
 
 #define SU_LOG_DOMAIN "params"
 
@@ -526,7 +527,7 @@ suscan_string_to_config(const suscan_config_desc_t *desc, const char *string)
         break;
 
       case SUSCAN_FIELD_TYPE_INTEGER:
-        if (sscanf(val, "%lli", &int_val) < 1) {
+        if (sscanf(val, "%"SCNi64, &int_val) < 1) {
           SU_ERROR("Invalid value for parameter `%s': `%s'\n", key, val);
           goto done;
         }
@@ -769,7 +770,7 @@ suscan_object_to_config(suscan_config_t *config, const suscan_object_t *object)
           break;
 
         case SUSCAN_FIELD_TYPE_INTEGER:
-          if (sscanf(val, "%lli", &int_val) < 1) {
+          if (sscanf(val, "%"SCNi64, &int_val) < 1) {
             SU_ERROR("Invalid value for parameter `%s': `%s'\n", key, val);
             goto done;
           }


### PR DESCRIPTION
I don't see an equivalent to `CLOCK_MONOTONIC_RAW` on FreeBSD, so I reached for the closest one I could find - `CLOCK_MONOTONIC`.  I'm not sure what exactly the timestamps are used for and therefore how sensitive to clock adjustments they are.

The other two commits are just simple changes.