### PR TITLE
Enable -Wall & address all the warnings generated

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ set(SUSCAN_PKGDIR "${CMAKE_INSTALL_PREFIX}" CACHE STRING
 string(REPLACE ";" " " SIGUTILS_SPC_CFLAGS "${SIGUTILS_CFLAGS}")
 string(REPLACE ";" " " SIGUTILS_SPC_LDFLAGS "${SIGUTILS_LDFLAGS}")
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${SIGUTILS_CONFIG_CFLAGS}")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall ${SIGUTILS_CONFIG_CFLAGS}")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DPKGDATADIR='\"${SUSCAN_PKGDIR}/share/suscan\"'")
 # The following hack exposes __FILENAME__ to source files as the relative
 # path of each source file.

--- a/analyzer/analyzer.c
+++ b/analyzer/analyzer.c
@@ -152,7 +152,7 @@ suscan_analyzer_register_baseband_filter(
     suscan_analyzer_baseband_filter_func_t func,
     void *privdata)
 {
-  struct suscan_analyzer_baseband_filter *new;
+  struct suscan_analyzer_baseband_filter *new = NULL;
 
   SU_TRYCATCH(
       self->params.mode == SUSCAN_ANALYZER_MODE_CHANNEL,
@@ -316,7 +316,6 @@ SUPRIVATE void *
 suscan_analyzer_thread(void *data)
 {
   suscan_analyzer_t *self = (suscan_analyzer_t *) data;
-  su_channel_detector_t *new_detector = NULL;
   struct sigutils_channel_detector_params new_det_params;
   const struct suscan_analyzer_params *new_params;
   const struct suscan_analyzer_throttle_msg *throttle;
@@ -730,10 +729,8 @@ done:
 void
 suscan_analyzer_destroy(suscan_analyzer_t *analyzer)
 {
-  uint32_t type;
   unsigned int i;
   struct suscan_inspector_overridable_request *req;
-  void *private;
 
   /* Prevent source from entering in timeout loops */
   if (analyzer->source != NULL)
@@ -900,8 +897,6 @@ suscan_analyzer_new(
   struct sigutils_specttuner_params st_params =
       sigutils_specttuner_params_INITIALIZER;
   struct sigutils_channel_detector_params det_params;
-  unsigned int worker_count;
-  unsigned int i;
 
 #ifdef DEBUG_ANALYZER_PARAMS
   suscan_analyzer_params_debug(params);

--- a/analyzer/insp-server.c
+++ b/analyzer/insp-server.c
@@ -321,8 +321,6 @@ suscan_analyzer_dispose_inspector_handle(
     suscan_analyzer_t *analyzer,
     SUHANDLE handle)
 {
-  struct suscan_inspector_overridable_request *req = NULL;
-
   if (handle < 0 || handle >= analyzer->inspector_count)
     return SU_FALSE;
 
@@ -531,12 +529,8 @@ suscan_analyzer_parse_inspector_msg(
     struct suscan_analyzer_inspector_msg *msg)
 {
   suscan_inspector_t *insp = NULL;
-  unsigned int i;
-  SUHANDLE handle = -1;
-  SUFLOAT f0, new_bw;
   SUBOOL ok = SU_FALSE;
   SUBOOL mutex_acquired = SU_FALSE;
-  SUBOOL update_baud;
 
   switch (msg->kind) {
     case SUSCAN_ANALYZER_INSPECTOR_MSGKIND_OPEN:

--- a/analyzer/inspector/impl/ask.c
+++ b/analyzer/inspector/impl/ask.c
@@ -344,15 +344,11 @@ suscan_ask_inspector_feed(
     SUSCOUNT count)
 {
   SUSCOUNT i;
-  SUSCOUNT osize = 0;
-  SUFLOAT alpha;
   SUCOMPLEX const_gain;
   SUCOMPLEX det_x;
   SUCOMPLEX output;
   SUBOOL new_sample = SU_FALSE;
   SUCOMPLEX last = 0;
-  unsigned int counts = 0;
-  struct timeval tv, otv, sub;
 
   struct suscan_ask_inspector *ask_insp =
       (struct suscan_ask_inspector *) private;

--- a/analyzer/inspector/impl/audio.c
+++ b/analyzer/inspector/impl/audio.c
@@ -263,6 +263,7 @@ suscan_audio_inspector_commit_config(void *private)
         break;
 
       default:
+        filt_initialized = SU_FALSE;
         break;
     }
 
@@ -292,7 +293,6 @@ suscan_audio_inspector_feed(
 {
   SUCOMPLEX last, det_x, output;
   SUSCOUNT i;
-  SUFLOAT alpha;
   SUCOMPLEX lo;
   struct suscan_audio_inspector *self =
       (struct suscan_audio_inspector *) private;

--- a/analyzer/inspector/impl/fsk.c
+++ b/analyzer/inspector/impl/fsk.c
@@ -320,8 +320,6 @@ suscan_fsk_inspector_feed(
     SUSCOUNT count)
 {
   SUSCOUNT i;
-  SUSCOUNT osize = 0;
-  SUFLOAT alpha;
   SUCOMPLEX const_gain;
   SUCOMPLEX det_x;
   SUCOMPLEX output;

--- a/analyzer/inspector/impl/psk.c
+++ b/analyzer/inspector/impl/psk.c
@@ -301,7 +301,6 @@ suscan_psk_inspector_commit_config(void *private)
   SUFLOAT actual_baud;
   SUFLOAT sym_period;
   su_costas_t costas;
-  enum sigutils_costas_kind kind;
 
   su_iir_filt_t mf = su_iir_filt_INITIALIZER;
   struct suscan_psk_inspector *insp = (struct suscan_psk_inspector *) private;
@@ -401,8 +400,6 @@ suscan_psk_inspector_feed(
     SUSCOUNT count)
 {
   SUSCOUNT i;
-  SUSCOUNT osize = 0;
-  SUFLOAT alpha;
   SUCOMPLEX det_x;
   SUCOMPLEX output;
   SUBOOL new_sample = SU_FALSE;

--- a/analyzer/inspsched.c
+++ b/analyzer/inspsched.c
@@ -37,7 +37,6 @@ suscan_inpsched_task_cb(
   suscan_inspsched_t *sched = (suscan_inspsched_t *) wk_private;
   struct suscan_inspector_task_info *task_info =
       (struct suscan_inspector_task_info *) cb_private;
-  unsigned int i;
 
   /*
    * We just process the incoming data. If we broke something,
@@ -243,7 +242,7 @@ suscan_inspsched_t *
 suscan_inspsched_new(suscan_analyzer_t *analyzer)
 {
   suscan_inspsched_t *new = NULL;
-  suscan_worker_t *worker;
+  suscan_worker_t *worker = NULL;
 
   unsigned int i, count;
 

--- a/analyzer/slow.c
+++ b/analyzer/slow.c
@@ -140,7 +140,6 @@ suscan_analyzer_set_antenna_cb(
   suscan_analyzer_t *analyzer = (suscan_analyzer_t *) wk_private;
   SUBOOL mutex_acquired = SU_FALSE;
   char *req = NULL;
-  unsigned int i;
 
   /* vvvvvvvvvvvvvvvvvv Acquire hotconf request mutex vvvvvvvvvvvvvvvvvvvvvvvvv */
   SU_TRYCATCH(pthread_mutex_lock(&analyzer->hotconf_mutex) != -1, goto fail);

--- a/analyzer/source.c
+++ b/analyzer/source.c
@@ -221,7 +221,6 @@ suscan_source_device_assert_gain(
 {
   unsigned int i;
   struct suscan_source_gain_desc *desc = NULL, *result = NULL;
-  SUBOOL ok = SU_FALSE;
 
   for (i = 0; i < dev->gain_desc_count; ++i) {
     if (strcmp(dev->gain_desc_list[i]->name, name) == 0) {
@@ -1745,7 +1744,6 @@ SUPRIVATE SUBOOL
 suscan_source_set_sample_rate_near(suscan_source_t *source)
 {
   double *rates = NULL;
-  size_t len;
   unsigned int i;
   SUFLOAT closest_rate = 0;
   SUFLOAT dist = INFINITY;

--- a/analyzer/spectsrc.c
+++ b/analyzer/spectsrc.c
@@ -111,7 +111,6 @@ suscan_spectsrc_new(
     enum sigutils_channel_detector_window window_type)
 {
   suscan_spectsrc_t *new = NULL;
-  unsigned int i;
 
   SU_TRYCATCH(new = calloc(1, sizeof(suscan_spectsrc_t)), goto fail);
 

--- a/analyzer/workers/channel.c
+++ b/analyzer/workers/channel.c
@@ -240,7 +240,6 @@ suscan_source_channel_wk_cb(
       su_channel_detector_get_window_size(analyzer->detector);
   SUBOOL mutex_acquired = SU_FALSE;
   SUBOOL restart = SU_FALSE;
-  unsigned int i;
   struct timespec sub;
   SUFLOAT seconds;
 

--- a/analyzer/workers/wide.c
+++ b/analyzer/workers/wide.c
@@ -188,7 +188,6 @@ suscan_analyzer_set_hop_range(
     SUFREQ min,
     SUFREQ max)
 {
-  SUBOOL mutex_acquired = SU_FALSE;
   SUBOOL ok = SU_FALSE;
 
   SU_TRYCATCH(
@@ -221,7 +220,6 @@ suscan_source_wide_wk_cb(
   SUSDIFF got;
   SUBOOL mutex_acquired = SU_FALSE;
   SUBOOL restart = SU_FALSE;
-  struct timespec sub;
 
   SU_TRYCATCH(suscan_analyzer_lock_loop(self), goto done);
   mutex_acquired = SU_TRUE;

--- a/src/fingerprint.c
+++ b/src/fingerprint.c
@@ -49,8 +49,6 @@ void
 suscan_fingerprint_report_destroy(
     struct suscan_fingerprint_report *report)
 {
-  unsigned int i;
-
   if (report->results != NULL)
     free(report->results);
 
@@ -118,7 +116,6 @@ suscan_close_all_channels(
     struct suscan_fingerprint_report *report)
 {
   unsigned int i;
-  SUHANDLE handle;
 
   for (i = 0; i < report->result_count; ++i)
     if (report->results[i].br_handle >= 0)
@@ -133,7 +130,6 @@ suscan_get_all_baudrates(
     struct suscan_fingerprint_report *report)
 {
   unsigned int i;
-  SUHANDLE handle;
 
   for (i = 0; i < report->result_count; ++i) {
     /* TODO: Implement */
@@ -184,8 +180,6 @@ suscan_perform_fingerprint(struct suscan_source_config *config)
   const struct suscan_analyzer_status_msg  *st_msg;
   struct suscan_fingerprint_report *report = NULL;
   unsigned int chskip = SUSCAN_CHLIST_SKIP_CHANNELS;
-  unsigned int i;
-  unsigned int n = 0;
   SUBOOL running = SU_TRUE;
   SUBOOL ok = SU_FALSE;
 

--- a/src/main.c
+++ b/src/main.c
@@ -62,7 +62,6 @@ main(int argc, char *argv[], char *envp[])
   struct timeval tv;
   int exit_code = EXIT_FAILURE;
   char *msgs;
-  unsigned int i;
   int c;
   int index;
 

--- a/util/cfg.c
+++ b/util/cfg.c
@@ -114,7 +114,7 @@ suscan_config_desc_add_field(
     const char *name,
     const char *desc)
 {
-  struct suscan_field *field;
+  struct suscan_field *field = NULL;
   char *name_dup = NULL;
   char *desc_dup = NULL;
 
@@ -595,11 +595,9 @@ done:
 char *
 suscan_config_to_string(const suscan_config_t *config)
 {
-  char *result = NULL;
   grow_buf_t gbuf = grow_buf_INITIALIZER;
   const struct suscan_field *field = NULL;
   const struct suscan_field_value *value = NULL;
-  char *terminator;
   char num_buffer[32];
   unsigned int i;
 

--- a/util/confdb.c
+++ b/util/confdb.c
@@ -252,7 +252,6 @@ suscan_config_context_scan(suscan_config_context_t *context)
   void *mmap_base = (void *) -1;
   suscan_object_t *set = NULL;
   struct stat sbuf;
-  size_t size;
 
   SUBOOL ok = SU_FALSE;
 
@@ -339,7 +338,6 @@ suscan_config_context_save(suscan_config_context_t *context)
   char *path = NULL;
   unsigned int i;
   int fd = -1;
-  suscan_object_t *set = NULL;
   size_t size;
   void *data = NULL;
   SUBOOL ok = SU_FALSE;

--- a/util/util.c
+++ b/util/util.c
@@ -62,7 +62,6 @@ char *
 vstrbuild(const char *fmt, va_list ap)
 {
   char *out;
-  void *p;
   int size, zeroindex;
   int last;
   va_list copy;
@@ -454,7 +453,7 @@ free_al (arg_list_t* al)
 static arg_list_t * 
 __split_command (const char *line, char *separators, int fixed_sep_size)
 {
-  int p, i;
+  int i;
 
   int split_flag;
   int escape_flag;
@@ -598,7 +597,6 @@ ltrim (const char *str)
 char *
 rtrim (const char *str)
 {
-  int i;
   char *copy;
   char *tail;
   
@@ -617,7 +615,6 @@ rtrim (const char *str)
 char *
 trim (const char *str)
 {
-  int i;
   char *copy;
   char *tail;
 


### PR DESCRIPTION
There were only two types of warnings:

 - unused variable
 - potentially uninitialized variable

The uninitialized variable warnings were all related to cleanup on
error.