### PR TITLE
fix ignored result warning

### DIFF
--- a/analyzer/impl/remote.c
+++ b/analyzer/impl/remote.c
@@ -551,7 +551,7 @@ suscan_remote_read(
     SU_TRYCATCH(poll(fds, 2, timeout_ms) != -1, return -1);
 
     if (fds[1].revents & POLLIN) {
-      (void) read(cancelfd, &cancel_byte, 1);
+      IGNORE_RESULT(int, read(cancelfd, &cancel_byte, 1));
       errno = ECANCELED;
       return -1;
     } else if (fds[0].revents & POLLIN) {
@@ -802,7 +802,7 @@ suscan_remote_analyzer_network_connect_cancellable(
       default:
         if (fds[1].revents & POLLIN) {
           /* Cancel requested */
-          (void) read(cancelfd, &cancel_byte, 1);
+          IGNORE_RESULT(int, read(cancelfd, &cancel_byte, 1));
           ret = -1;
           errno = ECANCELED;
           goto done;
@@ -1349,7 +1349,7 @@ suscan_remote_analyzer_dtor(void *ptr)
 
   if (self->tx_thread_init) {
     if (self->rx_thread_init) {
-      write(self->cancel_pipe[1], &b, 1);
+      IGNORE_RESULT(int, write(self->cancel_pipe[1], &b, 1));
       pthread_join(self->rx_thread, NULL);
     }
 
@@ -1890,4 +1890,3 @@ suscan_remote_analyzer_get_interface(void)
 }
 
 #undef SET_CALLBACK
-

--- a/cli/devserv/server.c
+++ b/cli/devserv/server.c
@@ -1082,7 +1082,7 @@ suscli_analyzer_server_cancel_rx_thread(suscli_analyzer_server_t *self)
 {
   char b = 1;
 
-  (void) write(self->cancel_pipefd[1], &b, 1);
+  IGNORE_RESULT(int, write(self->cancel_pipefd[1], &b, 1));
 }
 
 void
@@ -1129,5 +1129,3 @@ suscli_analyzer_server_destroy(suscli_analyzer_server_t *self)
 
   free(self);
 }
-
-

--- a/cli/devserv/tx.c
+++ b/cli/devserv/tx.c
@@ -133,7 +133,7 @@ suscli_analyzer_client_tx_thread_func(void *userdata)
 
     /* Cancelled via cancelfd */
     if (pollfds[1].revents & POLLIN) {
-      (void) read(self->cancel_pipefd[0], &b, 1);
+      IGNORE_RESULT(int, read(self->cancel_pipefd[0], &b, 1));
       goto done;
     }
 
@@ -178,7 +178,7 @@ suscli_analyzer_client_tx_thread_cancel(
    */
   suscan_mq_write_urgent(&self->queue, SUSCLI_ANALYZER_CLIENT_TX_CANCEL, NULL);
 
-  (void) write(self->cancel_pipefd[1], &b, 1);
+  IGNORE_RESULT(int, write(self->cancel_pipefd[1], &b, 1));
 }
 
 SUPRIVATE void


### PR DESCRIPTION
casting to (void) unfortunately does not work anymore. So another approach was used.
See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66425#c2