### PR TITLE
Add support for CMAKE modules.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ endforeach()
 
 include(FindPkgConfig)
 include(RelativeFileMacro)
+include(GNUInstallDirs)
 
 # Make sure CMAKE_INSTALL_LIBDIR is defined for all systems
 if(NOT DEFINED CMAKE_INSTALL_LIBDIR)
@@ -373,6 +374,8 @@ set_property(TARGET suscan PROPERTY SOVERSION ${SUSCAN_ABI})
 set_property(TARGET suscan PROPERTY COMPILE_FLAGS "${SIGUTILS_SPC_CFLAGS}")
 set_property(TARGET suscan PROPERTY LINK_FLAGS    "${SIGUTILS_SPC_LDFLAGS}")
 
+set_property(TARGET suscan PROPERTY EXPORT_NAME suscan)
+
 # Required dependencies
 if(APPLE)
   # Required to retrieve bundle path
@@ -388,6 +391,11 @@ if(WIN32)
     target_link_libraries(suscan regex)
   endif()
 endif()
+
+target_include_directories(suscan INTERFACE
+        $<INSTALL_INTERFACE:include>/${CMAKE_PROJECT_NAME}
+        $<INSTALL_INTERFACE:include>/${CMAKE_PROJECT_NAME}/util
+        )
 
 target_link_libraries(suscan m ${SIGUTILS_LIBRARIES})
 
@@ -416,6 +424,24 @@ if(VOLK_FOUND)
   target_include_directories(suscan SYSTEM PUBLIC ${VOLK_INCLUDE_DIRS})
   link_directories(${VOLK_LIBRARY_DIRS})
 endif()
+
+# export module
+set(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
+set(INSTALL_EXPORTS_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
+set(INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR})
+
+include(CMakePackageConfigHelpers)
+
+configure_package_config_file(
+        ${CMAKE_SOURCE_DIR}/cmake/suscanConfig.cmake.in
+        ${CMAKE_CURRENT_BINARY_DIR}/suscanConfig.cmake
+        INSTALL_DESTINATION ${INSTALL_EXPORTS_DIR}
+        PATH_VARS INCLUDE_INSTALL_DIR)
+
+write_basic_package_version_file(
+        ${CMAKE_BINARY_DIR}/suscanConfigVersion.cmake
+        VERSION ${PROJECT_VERSION}
+        COMPATIBILITY SameMajorVersion)
 
 install(
   FILES ${ANALYZER_LIB_HEADERS} 
@@ -457,7 +483,17 @@ install(
   FILES src/suscan.h
   DESTINATION include/suscan)
 
-install(TARGETS suscan DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/suscanConfig.cmake
+        ${CMAKE_BINARY_DIR}/suscanConfigVersion.cmake
+        DESTINATION ${INSTALL_EXPORTS_DIR})
+
+install(EXPORT suscan-export
+        FILE suscanTargets.cmake
+        NAMESPACE suscan::
+        DESTINATION ${INSTALL_EXPORTS_DIR})
+
+install(TARGETS suscan EXPORT suscan-export DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 ########################### Suscan test executable ############################
 set(SUSCAN_HEADERS ${SRCDIR}/suscan.h)

--- a/cmake/suscanConfig.cmake.in
+++ b/cmake/suscanConfig.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
+
+check_required_components("@PROJECT_NAME@")

--- a/doc/test/project/CMakeLists.txt
+++ b/doc/test/project/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.20.0)
+project(suscanTestPrj)
+
+find_package(suscan REQUIRED)
+
+add_executable(suscantest test.c)
+
+target_link_libraries(suscantest suscan::suscan)

--- a/doc/test/project/test.c
+++ b/doc/test/project/test.c
@@ -1,0 +1,14 @@
+//
+// Created by happycactus on 21/06/23.
+//
+#include <suscan/suscan.h>
+#include <suscan/analyzer/version.h>
+
+#include <stdio.h>
+
+int main(int argc, char *argv[])
+{
+    printf("suscan version: %s ABI: %d\n", suscan_api_version(),suscan_abi_version());
+
+    return 0;
+}


### PR DESCRIPTION
This PR adds the proper files to allow client project to automatically retrieve the cmake properties with `find_package` and `target_link_library(myproject suscan::suscan`.