### PR TITLE
Fix volk path build error on Mac with Homebrew

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -356,7 +356,8 @@ link_directories(
   ${FFTW3_LIBRARY_DIRS}
   ${SOAPYSDR_LIBRARY_DIRS}
   ${SIGUTILS_LIBRARY_DIRS}
-  ${XML2_LIBRARY_DIRS})
+  ${XML2_LIBRARY_DIRS}
+  ${VOLK_LIBRARY_DIRS})
  
 add_library(
   suscan SHARED
@@ -435,7 +436,6 @@ target_link_libraries(suscan ${CMAKE_THREAD_LIBS_INIT})
 if(VOLK_FOUND)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DHAVE_VOLK=1")
   target_include_directories(suscan SYSTEM PUBLIC ${VOLK_INCLUDE_DIRS})
-  link_directories(${VOLK_LIBRARY_DIRS})
 endif()
 
 install(


### PR DESCRIPTION
It needs to be included in the library search directories before the suscan library is declared in cmake, else the build command for suscan won't include the directive to search for libvolk in the special directory Homebrew put it. This works fine both with and without volk installed, as `VOLK_LIBRARY_DIRS` would just be blank without volk and not have any effect (I tested to make sure this doesn't break build without volk).