### PR TITLE
analyzer: add NULL check when stopping source

### DIFF
--- a/analyzer/impl/local.c
+++ b/analyzer/impl/local.c
@@ -735,7 +735,7 @@ suscan_local_analyzer_dtor(void *ptr)
     }
 
   /* Stop capture source, now that workers using it have stopped */
-  if (suscan_source_is_capturing(self->source))
+  if (self->source != NULL && suscan_source_is_capturing(self->source))
     suscan_source_stop_capture(self->source);
 
   /* Destroy global inspector table */


### PR DESCRIPTION
If there is no valid source, this will result in a NULL dereference without the check. This fixes a regression introduced by my earlier fix regarding stopping analyzers.