### PR TITLE
Miscellaneous fixes

### DIFF
--- a/analyzer/source/config.c
+++ b/analyzer/source/config.c
@@ -724,6 +724,9 @@ suscan_source_config_set_device(
 {
   unsigned int i;
 
+  if (config->device == dev && config->interface == dev->interface)
+    return SU_TRUE; /* nothing to do */
+
   /*
    * TODO: Once this API is fixed, allocate new soapy_args and replace
    * the old ones.

--- a/analyzer/source/impl/soapysdr.c
+++ b/analyzer/source/impl/soapysdr.c
@@ -96,6 +96,15 @@ suscan_source_soapysdr_init_sdr(struct suscan_source_soapysdr *self)
     goto done;
   }
 
+  if (SoapySDRDevice_setSampleRate(
+      self->sdr,
+      SOAPY_SDR_RX,
+      config->channel,
+      config->samp_rate) != 0) {
+    SU_ERROR("Failed to set sample rate: %s\n", SoapySDRDevice_lastError());
+    goto done;
+  }
+
   if (SoapySDRDevice_setBandwidth(
       self->sdr,
       SOAPY_SDR_RX,
@@ -122,15 +131,6 @@ suscan_source_soapysdr_init_sdr(struct suscan_source_soapysdr *self)
       SOAPY_SDR_ABI_VERSION
       " does not support frequency correction\n");
 #endif /* SOAPY_SDR_API_VERSION >= 0x00060000 */
-
-  if (SoapySDRDevice_setSampleRate(
-      self->sdr,
-      SOAPY_SDR_RX,
-      config->channel,
-      config->samp_rate) != 0) {
-    SU_ERROR("Failed to set sample rate: %s\n", SoapySDRDevice_lastError());
-    goto done;
-  }
 
   /* TODO: Implement IQ balance*/
   self->have_dc = SoapySDRDevice_hasDCOffsetMode(


### PR DESCRIPTION
- Making the channelizer FFT size independent of smoothpsd (waterfall) FFT size allows the channelizer to remain consistently fast regardless of how the user wants the waterfall to look
- Avoid unnecessarily losing the device tweaks (when SigDigger calls to set the device to the same device already selected)
- Reorder bandwidth setting to after sample rate setting, because some SDRs like USRP reset their bandwidth when sample rate is set