### PR TITLE
Panoramic spectrum improvements and fixes

### DIFF
--- a/analyzer/impl/local.c
+++ b/analyzer/impl/local.c
@@ -164,6 +164,8 @@ SUBOOL suscan_source_wide_wk_cb(
     void *wk_private,
     void *cb_private);
 
+SUBOOL suscan_local_analyzer_init_channel_worker(suscan_local_analyzer_t *self);
+SUBOOL suscan_local_analyzer_init_wide_worker(suscan_local_analyzer_t *self);
 SUBOOL suscan_local_analyzer_start_channel_worker(suscan_local_analyzer_t *self);
 SUBOOL suscan_local_analyzer_start_wide_worker(suscan_local_analyzer_t *self);
 
@@ -614,6 +616,16 @@ suscan_local_analyzer_ctor(suscan_analyzer_t *parent, va_list ap)
     suscan_source_info_init_copy(
       &new->source_info,
       suscan_source_get_info(new->source)));
+
+  if (parent->params.mode == SUSCAN_ANALYZER_MODE_WIDE_SPECTRUM) {
+    SU_TRYCATCH(
+        suscan_local_analyzer_init_wide_worker(new),
+        goto fail);
+  } else {
+    SU_TRYCATCH(
+        suscan_local_analyzer_init_channel_worker(new),
+        goto fail);
+  }
 
   /* Get ahead of the initialization. analyzer_thread
      need this to be properly initialized. */

--- a/analyzer/impl/local.h
+++ b/analyzer/impl/local.h
@@ -139,6 +139,7 @@ struct suscan_local_analyzer {
   SUFREQ   curr_freq;
   SUSCOUNT part_ndx;
   SUSCOUNT fft_samples; /* Number of FFT frames */
+  SUSCOUNT hop_samples;
 
   suscan_inspector_factory_t         *insp_factory;
   suscan_inspector_request_manager_t  insp_reqmgr;

--- a/analyzer/source.h
+++ b/analyzer/source.h
@@ -48,6 +48,8 @@ extern "C" {
 
 #define SUSCAN_SOURCE_SETTING_PREFIX    "setting:"
 #define SUSCAN_SOURCE_SETTING_PFXLEN    (sizeof("setting:") - 1)
+#define SUSCAN_STREAM_SETTING_PREFIX    "stream:"
+#define SUSCAN_STREAM_SETTING_PFXLEN    (sizeof("stream:") - 1)
 
 #define SUSCAN_SOURCE_DEFAULT_READ_TIMEOUT 100000 /* 100 ms */
 #define SUSCAN_SOURCE_ANTIALIAS_REL_SIZE    5

--- a/analyzer/source/impl/soapysdr.h
+++ b/analyzer/source/impl/soapysdr.h
@@ -34,11 +34,13 @@ struct suscan_source;
 struct suscan_source_soapysdr {
   struct suscan_source_config *config;
   struct suscan_source        *source;
-  
+
   SoapySDRDevice  *sdr;
   SoapySDRStream  *rx_stream;
   SoapySDRArgInfo *settings;
   size_t           settings_count;
+  SoapySDRArgInfo *stream_args;
+  size_t           stream_args_count;
 
   size_t chan_array[1];
   SUFLOAT samp_rate; /* Actual sample rate */

--- a/analyzer/workers/wide.c
+++ b/analyzer/workers/wide.c
@@ -255,7 +255,7 @@ suscan_local_analyzer_init_detector_params(
 }
 
 SUBOOL
-suscan_local_analyzer_start_wide_worker(suscan_local_analyzer_t *self)
+suscan_local_analyzer_init_wide_worker(suscan_local_analyzer_t *self)
 {
   struct sigutils_channel_detector_params det_params;
   SUBOOL ok = SU_FALSE;
@@ -282,13 +282,24 @@ suscan_local_analyzer_start_wide_worker(suscan_local_analyzer_t *self)
   SU_TRY(
       self->parent->params.max_freq - self->parent->params.min_freq >=
       self->source_info.source_samp_rate);
-  
+
   self->current_sweep_params.fft_min_samples =
           SUSCAN_ANALYZER_MIN_POST_HOP_FFTS * det_params.window_size;
   self->current_sweep_params.max_freq = self->parent->params.max_freq;
   self->current_sweep_params.min_freq = self->parent->params.min_freq;
   self->current_sweep_params.rel_bw = 0.5;
   self->sweep_params_requested = SU_FALSE;
+
+  ok = SU_TRUE;
+
+done:
+  return ok;
+}
+
+SUBOOL
+suscan_local_analyzer_start_wide_worker(suscan_local_analyzer_t *self)
+{
+  SUBOOL ok = SU_FALSE;
 
   if (!suscan_worker_push(
     self->source_wk,

--- a/analyzer/workers/wide.c
+++ b/analyzer/workers/wide.c
@@ -97,6 +97,9 @@ suscan_local_analyzer_hop(suscan_local_analyzer_t *self)
           if (next > self->current_sweep_params.max_freq) {
             next = self->current_sweep_params.min_freq + step_size * 0.5
                 - freq_jiggle;
+          } else if (next < self->current_sweep_params.min_freq) {
+            /* can happen on first run when self->curr_freq may be invalid */
+            next = self->current_sweep_params.min_freq;
           }
         }
         break;


### PR DESCRIPTION
- Redefine `fft_min_samples` (computed from RTT field of panoramic dialog) to not include retune time. Now this field represents the number of samples to discard due to buffering of data.
- Allow setting stream arguments such as RTL-SDR buffer size
- Fix initial setting of setting sweep strategy and relative bandwidth from SigDigger
- Fix invalid initial frequency during continuous progressive sweep