### PR TITLE
More panoramic spectrum improvements

### DIFF
--- a/analyzer/workers/wide.c
+++ b/analyzer/workers/wide.c
@@ -93,8 +93,13 @@ suscan_local_analyzer_hop(suscan_local_analyzer_t *self)
           next = part_bw * self->part_ndx++
             + self->current_sweep_params.min_freq;
           if (next > self->current_sweep_params.max_freq) {
-            next = self->current_sweep_params.min_freq;
-            self->part_ndx = 1;
+            if (self->curr_freq < self->current_sweep_params.max_freq - part_bw * 0.5) {
+              next = self->current_sweep_params.max_freq;
+              self->part_ndx = 0;
+            } else {
+              next = self->current_sweep_params.min_freq;
+              self->part_ndx = 1;
+            }
           }
         } else {
           /* Continuous: advance monotonically in randomized steps */
@@ -102,8 +107,12 @@ suscan_local_analyzer_hop(suscan_local_analyzer_t *self)
           SUFLOAT freq_jiggle = SU_FLOOR(step_size * rnd * 0.2);
           next = self->curr_freq + step_size - freq_jiggle;
           if (next > self->current_sweep_params.max_freq) {
-            next = self->current_sweep_params.min_freq + step_size * 0.5
-                - freq_jiggle;
+            if (self->curr_freq < self->current_sweep_params.max_freq - step_size * 0.5) {
+              next = self->current_sweep_params.max_freq - freq_jiggle;
+            } else {
+              next = self->current_sweep_params.min_freq + step_size * 0.5
+                  - freq_jiggle;
+            }
           } else if (next < self->current_sweep_params.min_freq) {
             /* can happen on first run when self->curr_freq may be invalid */
             next = self->current_sweep_params.min_freq;

--- a/analyzer/workers/wide.c
+++ b/analyzer/workers/wide.c
@@ -293,9 +293,7 @@ suscan_local_analyzer_init_wide_worker(suscan_local_analyzer_t *self)
     SU_TRY(suscan_local_analyzer_readjust_detector(self, &det_params));
   }
 
-  SU_TRY(
-      self->parent->params.max_freq - self->parent->params.min_freq >=
-      self->source_info.source_samp_rate);
+  SU_TRY(self->parent->params.max_freq >= self->parent->params.min_freq);
 
   self->current_sweep_params.fft_min_samples =
           SUSCAN_ANALYZER_MIN_POST_HOP_FFTS * det_params.window_size;


### PR DESCRIPTION
- Allow starting the wide worker in non-hopping mode (for very zoomed startup), or hopping over a range less than the sample rate (due to relative bandwidth discarding edges)
- Fix the progressive continuous sweep strategy logic to always cover the whole frequency range including the end